### PR TITLE
Changes to CI.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ PC/* linguist-vendored
 etc/* linguist-vendored
 .github/* linguist-vendored
 get_externals.bat linguist-vendored
+ci_build.bat linguist-vendored

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,14 @@ max_jobs: 15
 image: Visual Studio 2017
 configuration: Release
 platform: x86
+
 before_build:
-- cmd: call get_externals.bat && call externals\cpython\PCBuild\build.bat
+- cmd: call ci_build.bat
+
+cache:
+  - .\externals\cpython -> .\externals\cpython\*.*
+  - .\externals\aes -> .\externals\aes\*.*
+
 build:
   project: Els_kom_Solution.sln
   parallel: true

--- a/ci_build.bat
+++ b/ci_build.bat
@@ -1,0 +1,10 @@
+call get_externals.bat
+cd externals\cpython
+REM update cpython extenal if needed.
+git pull
+cd ..\aes
+REM update aes extenal if needed.
+git pull
+cd ..\..
+REM rebuild / build cpython.
+call externals\cpython\PCBuild\build.bat


### PR DESCRIPTION
## Change Description
<!--
Describe the issue you have fixed here.
-->
Cache the externals per build.

This should hopefully reduce the time it takes to build by not running the clone all the time.