### PR TITLE
Made building python optional in CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,9 @@
 PC/encryption_private.h
 Python/komformat.private.py
 Python/private_encryption.py
-obj/*.*
-bin/*.*
+obj
+bin
+old
+aes
+externals/aes
+externals/cpython

--- a/Python/get_python_build_hash.py
+++ b/Python/get_python_build_hash.py
@@ -6,12 +6,14 @@ import subprocess
 def get_git_hash():
     return sys._git[2]
 
+
 def get_current_git_hash():
     proc = subprocess.Popen(
         'git rev-parse --short HEAD ',
         stdout=subprocess.PIPE, universal_newlines=True)
     proc.wait()
     return proc.stdout
+
 
 def main():
     if get_git_hash() == get_current_git_hash():
@@ -21,5 +23,6 @@ def main():
         print("Rebuilding Python...")
         proc = subprocess.Popen(os.path.join(sys.path[5], 'PCbuild', 'build.bat'), universal_newlines=True)
         proc.wait()
+
 
 main()

--- a/Python/get_python_build_hash.py
+++ b/Python/get_python_build_hash.py
@@ -1,0 +1,25 @@
+import sys
+import os
+import subprocess
+
+
+def get_git_hash():
+    return sys._git[2]
+
+def get_current_git_hash():
+    proc = subprocess.Popen(
+        'git rev-parse --short HEAD ',
+        stdout=subprocess.PIPE, universal_newlines=True)
+    proc.wait()
+    return proc.stdout
+
+def main():
+    if get_git_hash() == get_current_git_hash():
+        print("Python build is already on latest commit.")
+        return 0
+    else:
+        print("Rebuilding Python...")
+        proc = subprocess.Popen(os.path.join(sys.path[5], 'PCbuild', 'build.bat'), universal_newlines=True)
+        proc.wait()
+
+main()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ max_jobs: 15
 image: Visual Studio 2017
 configuration: Release
 platform: x86
+test: off
 
 before_build:
 - cmd: call ci_build.bat

--- a/ci_build.bat
+++ b/ci_build.bat
@@ -1,10 +1,9 @@
+@echo off
 call get_externals.bat
 cd externals\cpython
-REM update cpython extenal if needed.
 git pull
+REM build/rebuild python if needed.
+"PCbuild\win32\python.exe" "..\..\Python\get_python_build_hash.py"
 cd ..\aes
-REM update aes extenal if needed.
 git pull
 cd ..\..
-REM rebuild / build cpython.
-call externals\cpython\PCBuild\build.bat


### PR DESCRIPTION
Now Python will only build if CI cached build is older than the leatest
and greatest python 3.6 branch build.

## Change Description
<!--
Describe the issue you have fixed here.
-->
Made Python will build if CI cached build is older than the leatest and greatest python 3.6 branch commit.