### PR TITLE
Fixed crash on new Els_kom users.

### DIFF
--- a/Els_kom_Core/Classes/XMLObject.cs
+++ b/Els_kom_Core/Classes/XMLObject.cs
@@ -161,7 +161,6 @@ namespace Els_kom_Core.Classes
         ///
         /// If Element does not exist yet it will be created automatically with an empty value.
         /// </summary>
-        /// <exception cref="System.ArgumentException">Thrown if element does not exist yet in the XMLObject.</exception>
         /// <exception cref="System.ObjectDisposedException">XMLOblect is disposed.</exception>
         public string Read(string elementname)
         {

--- a/Els_kom_Core/Controls/MainControl.cs
+++ b/Els_kom_Core/Controls/MainControl.cs
@@ -270,17 +270,9 @@ namespace Els_kom_Core.Controls
             }
             else
             {
-                if (System.IO.File.Exists(Classes.SettingsFile.Path))
-                {
-                    Classes.SettingsFile.Settingsxml = new Classes.XMLObject(Classes.SettingsFile.Path, "<Settings></Settings>");
-                    ElsDir = Classes.SettingsFile.Settingsxml.Read("ElsDir");
-                    if (ElsDir.Length < 1)
-                    {
-                        Classes.MessageManager.ShowInfo("Welcome to Els_kom." + System.Environment.NewLine + "Now your fist step is to Configure Els_kom to the path that you have installed Elsword to and then you can Use the test Mods and the executing of the Launcher features. It will only take less than 1~3 minutes tops." + System.Environment.NewLine + "Also if you encounter any bugs or other things take a look at the Issue Tracker.", "Welcome!");
-                        ConfigForm?.Invoke(this, new System.EventArgs());
-                    }
-                }
-                else
+                Classes.SettingsFile.Settingsxml = new Classes.XMLObject(Classes.SettingsFile.Path, "<Settings></Settings>");
+                ElsDir = Classes.SettingsFile.Settingsxml.Read("ElsDir");
+                if (ElsDir.Length < 1)
                 {
                     Classes.MessageManager.ShowInfo("Welcome to Els_kom." + System.Environment.NewLine + "Now your fist step is to Configure Els_kom to the path that you have installed Elsword to and then you can Use the test Mods and the executing of the Launcher features. It will only take less than 1~3 minutes tops." + System.Environment.NewLine + "Also if you encounter any bugs or other things take a look at the Issue Tracker.", "Welcome!");
                     ConfigForm?.Invoke(this, new System.EventArgs());

--- a/Misc/NEWS/1.4.9.8/item031
+++ b/Misc/NEWS/1.4.9.8/item031
@@ -1,0 +1,1 @@
+Fixed crash when saving settings in the Settings Window. This was related to old code in the MainControl file that would open the Settings Window when the settings file is not found without a real instance of XMLObject resulting in a crash upon saving.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ version: 1.4.9.8a{build}
 branches:
   except:
   - next
+skip_commits:
+  files:
+    - Misc/NEWS/
 max_jobs: 15
 image:
 - Visual Studio 2017


### PR DESCRIPTION
It seems we should have optimized this since XMLObject itself checks for it’s existence.

## Change Description
<!--
Describe the issue you have fixed here.
-->

## Debug information
<!--
Information the fix is for.
-->
- Els_kom version: ``[your version here]``
- OS: ``[Your OS version here]``
- OS Arch: ``[Your OS Arch here]``
- OS Build: ``[Your OS Build here]``
